### PR TITLE
New polaris icons

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @shopify/payments-buyer-experience
+*       @shopify/merchant-and-partner-experience

--- a/app/routes/app.dashboard.jsx
+++ b/app/routes/app.dashboard.jsx
@@ -1,7 +1,7 @@
 import { json, redirect } from "@remix-run/node";
 import { useLoaderData, useSubmit } from "@remix-run/react";
 import { Page, Card, DataTable, Button, Text, LegacyStack, Icon } from "@shopify/polaris";
-import { MinusMinor, TickMinor } from "@shopify/polaris-icons";
+import { MinusIcon, CheckSmallIcon } from "@shopify/polaris-icons";
 
 import { getPaymentSessions } from "~/payments.repository";
 
@@ -35,8 +35,8 @@ export default function Dashboard() {
     <LegacyStack>
       {
         isVoid
-          ? (<Icon source={TickMinor} color="critical"/>)
-          : (<Icon source={MinusMinor} color="primary"/>)
+          ? (<Icon source={CheckSmallIcon} color="critical"/>)
+          : (<Icon source={MinusIcon} color="primary"/>)
       }
     </LegacyStack>
   );

--- a/app/routes/app.dashboard_simulator.$paymentId.jsx
+++ b/app/routes/app.dashboard_simulator.$paymentId.jsx
@@ -13,7 +13,7 @@ import {
   DataTable,
   Modal,
 } from "@shopify/polaris";
-import { CancelSmallMinor, TickMinor } from "@shopify/polaris-icons";
+import { XSmallIcon, CheckSmallIcon } from "@shopify/polaris-icons";
 import { useState, useCallback, useEffect } from "react";
 import {
   useActionData,
@@ -144,7 +144,7 @@ export default function DashboardSimulator() {
   const activator = (session, type) => {
     if (!session.status || session.status === PENDING)
       return <Button onClick={() => raiseModal(session, type)}>Open</Button>
-    return <Icon source={TickMinor} />
+    return <Icon source={CheckSmallIcon} />
   }
 
   const refundRows = refundSessions.map((refund) => [
@@ -315,8 +315,8 @@ const buildPaymentItems = (paymentSession, activator) => {
         <LegacyStack>
           {
             paymentSession.test
-              ? (<Icon source={TickMinor} color="primary"/>)
-              : (<Icon source={CancelSmallMinor} color="critical"/>)
+              ? (<Icon source={CheckSmallIcon} color="primary"/>)
+              : (<Icon source={XSmallIcon} color="critical"/>)
           }
         </LegacyStack>
       )

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^1.19.1",
     "@remix-run/eslint-config": "^2.0.0",
     "@shopify/api-codegen-preset": "^0.0.1",
     "@shopify/app-bridge-types": "^0.0.3",


### PR DESCRIPTION
### WHY are these changes introduced?

- The current icons are breaking. 
- CODEOWNERS is out-of-date
- `npm ERR! While resolving: @remix-run/dev@1.19.3`

### WHAT is this pull request doing?

- Uses new icons
- References the new team that owns this service
- Remove broken dependency. `@remix-run/dev@2.0.0` is already required anyway

related: https://github.com/Shopify/example-app--payments-app-template--remix/pull/54