### PR TITLE
Add information about network transaction id

### DIFF
--- a/app/payments-apps.graphql.js
+++ b/app/payments-apps.graphql.js
@@ -48,6 +48,9 @@ export default class PaymentsAppsClient {
 
     if (this.type === PAYMENT && kind === 'authorization') payload['authorizationExpiresAt'] = this.tomorrow.toISOString();
 
+    // Pass the networkTransactionId in the payload if it is available from network response
+    if (session.networkTransactionId) payload['networkTransactionId'] = session.networkTransactionId;
+
     const response = await this.#perform(schema[this.resolveMutation], payload);
     const responseData = response[this.resolveMutation]
     if (responseData?.userErrors?.length === 0) await this.update?.(id, RESOLVE);
@@ -168,7 +171,7 @@ export default class PaymentsAppsClient {
    * @returns
    */
   dependencyInjector(type) {
-    switch(type) {
+    switch (type) {
       case PAYMENT:
         this.resolveMutation = "paymentSessionResolve"
         this.rejectMutation = "paymentSessionReject"

--- a/app/payments-apps.schema.js
+++ b/app/payments-apps.schema.js
@@ -16,12 +16,14 @@ const paymentSessionResolve = `
   mutation PaymentSessionResolve(
     $id: ID!,
     $authorizationExpiresAt: DateTime,
-    $authentication: PaymentSessionThreeDSecureAuthentication
+    $authentication: PaymentSessionThreeDSecureAuthentication,
+    $networkTransactionId: String
   ) {
     paymentSessionResolve(
       id: $id,
       authorizationExpiresAt: $authorizationExpiresAt,
-      authentication: $authentication
+      authentication: $authentication,
+      networkTransactionId: $networkTransactionId
     ) {
       paymentSession {
         id


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

An additional change to this PR: https://github.com/Shopify/shopify-dev/pull/53069

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

We are adding missing mentions of `networkTransactionId` value being available on the `paymentSessionResolve`

As a result the code sample will look like this in shopify.dev

![paymentSessionResolve section](https://screenshot.click/13-38-acvdz-n3hed.png)

### Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable