### PR TITLE
Fix extra missing spaces to the start and ending tags

### DIFF
--- a/app/routes/app.three-d-secure.$paymentId.jsx
+++ b/app/routes/app.three-d-secure.$paymentId.jsx
@@ -37,7 +37,7 @@ export const loader = async ({request, params: { paymentId } }) => {
   const session = (await sessionStorage.findSessionsByShop(paymentSession.shop))[0];
   const client = new PaymentsAppsClient(session.shop, session.accessToken, PAYMENT);
 
-  // [START build-credit-card-payments-app.frictionless ]
+  // [START build-credit-card-payments-app.frictionless]
   if (frictionless) { // Perform frictionless 3DS
     const authenticationPayload = {
       authenticationFlow: Object.keys(ThreeDSecure.flow)[0],
@@ -52,7 +52,7 @@ export const loader = async ({request, params: { paymentId } }) => {
 
     return redirect(response.paymentSession.nextAction.context.redirectUrl);
   }
-  // [END build-credit-card-payments-app.frictionless ]
+  // [END build-credit-card-payments-app.frictionless]
 
   return json({ paymentSession });
 }
@@ -60,7 +60,7 @@ export const loader = async ({request, params: { paymentId } }) => {
 /**
  * Completes a 3DS session based on the simulator's form
  */
-// [START build-credit-card-payments-app.next-action ]
+// [START build-credit-card-payments-app.next-action]
 export const action = async ({ request, params: { paymentId } }) => {
   const formData = await request.formData();
   const data = Object.fromEntries(formData);
@@ -92,7 +92,7 @@ export const action = async ({ request, params: { paymentId } }) => {
 
   return redirect(response.paymentSession.nextAction.context.redirectUrl);
 }
-// [END build-credit-card-payments-app.next-action ]
+// [END build-credit-card-payments-app.next-action]
 
 export default function threeDSSimulator() {
   const action = useActionData();


### PR DESCRIPTION
## TL;DR

  Coderef tags in app.three-d-secure.$paymentId.jsx on the docs branch had trailing
  spaces before the closing ], causing CodeRevealerTagError in shopify-dev when rendering
   the credit card payments tutorial.

  Removed the trailing spaces from all 4 [START ...] / [END ...] tags so the
  documentation code revealer can match them correctly.

## Context

The shopify-dev documentation uses <CodeRef tag="..."> components that extract code
snippets between [START tag-name] / [END tag-name] markers in source files. The
frictionless and next-action tags in this file were written as [START tag-name ] (with
a trailing space), which doesn't match the parser's expected format. This was flagged
by a new tag validation check in https://github.com/Shopify/shopify-dev/pull/67820.

## What should reviewers focus on

- Confirm the tags now match the format used in every other file on the docs branch (no trailing space before ])
- This is a whitespace-only fix across 4 lines - no logic changes

## Oncall

`@spy oncall payments-platform`